### PR TITLE
Mention the configuration inheritance option

### DIFF
--- a/docs/setup/setting-up-social-cards.md
+++ b/docs/setup/setting-up-social-cards.md
@@ -59,7 +59,8 @@ The following configuration options are available:
 
 :   :octicons-milestone-24: Default: `true` – This option specifies whether
     to generate social card images. If you want to switch the plugin off, e.g.
-    for local builds, you can use an [environment variable]:
+    for local builds, you can either use MkDocs [configuration inheritance],
+    as described in [built-in-plugins], or use an [environment variable]:
 
     ``` yaml
     plugins:
@@ -116,6 +117,8 @@ The following configuration options are available:
   [environment variable]: https://www.mkdocs.org/user-guide/configuration/#environment-variables
   [CSS color keywords]: https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#color_keywords
   [Google Fonts]: https://fonts.google.com
+  [built-in-plugins]: ../insiders/getting-started/#built-in-plugins
+  [configuration inheritance]: https://www.mkdocs.org/user-guide/configuration/#configuration-inheritance
 
 #### Dependencies
 


### PR DESCRIPTION
The config inheritance option is to prefer for disabling the social plugin entirely, I think, but maybe for some use cases it is easier with environment variables?